### PR TITLE
WIP: Modified run to send non-jsonable objects

### DIFF
--- a/dlhub_sdk/client.py
+++ b/dlhub_sdk/client.py
@@ -47,7 +47,7 @@ class DLHubClient:
         serv = df_tmp[df_tmp.name == name]
         return serv.iloc[0]['uuid']
 
-    def run(self, servable_id, inputs, input_type='python'):
+    def run(self, servable_id, inputs, input_type='json'):
         """Invoke a DLHub servable
 
         Args:

--- a/dlhub_sdk/client.py
+++ b/dlhub_sdk/client.py
@@ -1,8 +1,11 @@
 from dlhub_sdk.utils.schemas import validate_against_dlhub_schema
 from tempfile import mkstemp
+import pickle as pkl
 import pandas as pd
 import requests
+import codecs
 import boto3
+import json
 import uuid
 import os
 
@@ -44,22 +47,38 @@ class DLHubClient:
         serv = df_tmp[df_tmp.name == name]
         return serv.iloc[0]['uuid']
 
-    def run(self, servable_id, data):
+    def run(self, servable_id, inputs, input_type='python'):
         """Invoke a DLHub servable
 
         Args:
             servable_id (string): UUID of the servable
-            data (dict): Dictionary of the data to send to the servable
+            inputs: Data to be used as input to the function. Can be a string of file paths or URLs
+            input_type (string): How to send the data to DLHub. Can be "python" (which pickles
+                the data), "json" (which uses JSON to serialize the data), or "files" (which
+                sends the data as files).
         Returns:
-            (pd.DataFrame): Reply from the service
+            Reply from the service
         """
         servable_path = '{service}/servables/{servable_id}/run'.format(service=self.service,
                                                                        servable_id=servable_id)
 
+        # Prepare the data to be sent to DLHub
+        if input_type == 'python':
+            data = {'python': codecs.encode(pkl.dumps(inputs), 'base64').decode()}
+        elif input_type == 'json':
+            data = {'data': inputs}
+        elif input_type == 'files':
+            raise NotImplementedError('Files support is not yet implemented')
+        else:
+            raise ValueError('Input type not recognized: {}'.format(input_type))
+
+        # Send the data to DLHub
         r = requests.post(servable_path, json=data, timeout=self.timeout)
         if r.status_code is not 200:
             raise Exception(r)
-        return pd.DataFrame(r.json())
+
+        # Return the result
+        return r.json()
 
     def publish_servable(self, model):
         """Submit a servable to DLHub

--- a/dlhub_sdk/tests/test_dlhub_client.py
+++ b/dlhub_sdk/tests/test_dlhub_client.py
@@ -35,10 +35,14 @@ class TestClient(TestCase):
         name = "noop"
         data = {"data": ["V", "Co", "Zr"]}
         serv = dl.get_id_by_name(name)
-        res = dl.run(serv, data)
 
-        # Check the results
-        self.assertIsInstance(res, pd.DataFrame)
+        # Test sending the data as JSON
+        res = dl.run(serv, data, input_type='json')
+        self.assertEqual({}, res)
+
+        # Test sending the data as pickle
+        res = dl.run(serv, data, input_type='pickle')
+        self.assertEqual({}, res)
 
     @skip  # Do not yet have a "test" route for submitted objects
     def test_submit(self):


### PR DESCRIPTION
Modification to the client for sending Python objects to DLHub. Is not yet supported by the server.