### PR TITLE
Bug Fix: Calling `to_dict` changes self in MetadataModel

### DIFF
--- a/dlhub_sdk/models/__init__.py
+++ b/dlhub_sdk/models/__init__.py
@@ -4,6 +4,7 @@ from itertools import zip_longest
 from datetime import datetime
 from six import string_types
 from zipfile import ZipFile
+from copy import deepcopy
 from glob import glob
 import json
 import sys
@@ -431,7 +432,7 @@ class BaseMetadataModel:
             raise ValueError('Name must be specified. Use `set_name`')
 
         # Make a copy of the output
-        out = dict(self._output)
+        out = deepcopy(self._output)
 
         # Add the name of the class to the output, if desired
         if save_class_data:
@@ -465,7 +466,7 @@ class BaseMetadataModel:
 
         # Create the object, overwrite data
         output = cls()
-        output._output = dict(data)
+        output._output = deepcopy(data)
 
         # Make sure the class information is removed
         if '@class' in output._output:

--- a/dlhub_sdk/models/tests/test_datasets.py
+++ b/dlhub_sdk/models/tests/test_datasets.py
@@ -148,6 +148,9 @@ class TestModels(unittest.TestCase):
         metadata = m.to_dict(simplify_paths=True)
         self.assertEqual({'data': 'test.csv'}, metadata['dlhub']['files'])
 
+        # Make sure the paths saved in the object have not changed
+        self.assertEqual({'data': data_path}, m['dlhub']['files'])
+
     def test_zip(self):
         """Test generating a zip file with the requested files"""
 


### PR DESCRIPTION
When outputting the metadata dictionary in metadata model, the information in the model changes if you request simplified paths. This causes problems in the model publication process.