### PR TITLE
Added support for functions with >1 input arg

### DIFF
--- a/dlhub_sdk/models/servables/python.py
+++ b/dlhub_sdk/models/servables/python.py
@@ -16,6 +16,23 @@ class BasePythonServableModel(BaseServableModel):
             'language': 'python',
         })
 
+    def set_unpack_inputs(self, x, method_name='run'):
+        """Define whether the inputs need to be unpacked before executing the function
+
+        Set to `true` if the function takes more than one input. Otherwise, the default is `False`
+
+        Args:
+            x (bool): Desired setting
+            method_name (str): Name of the method to modify
+        Returns:
+            (BasePythonServableModel): self
+        """
+
+        if self['servable']['methods'][method_name]['input']['type'] not in ['list', 'tuple']:
+            raise ValueError('Only "list" and "tuple" inputs are compatible with unpacking')
+        self['servable']['methods'][method_name]['method_details']['unpack'] = x
+        return self
+
     @classmethod
     def create_model(cls, method, function_kwargs=None):
         """Initialize a model for a python object

--- a/dlhub_sdk/models/servables/tests/test_python.py
+++ b/dlhub_sdk/models/servables/tests/test_python.py
@@ -195,7 +195,8 @@ class TestPythonModels(unittest.TestCase):
         """Test making descriptions with more than one argument"""
 
         # Initialize the model
-        model = PythonStaticMethodModel.from_function_pointer(max).set_name('test').set_title('test')
+        model = PythonStaticMethodModel.from_function_pointer(max)
+        model.set_name('test').set_title('test')
 
         # Define the inputs and outputs
         model.set_inputs('tuple', 'Two numbers',

--- a/dlhub_sdk/models/servables/tests/test_python.py
+++ b/dlhub_sdk/models/servables/tests/test_python.py
@@ -3,6 +3,7 @@
 from dlhub_sdk.models.servables.python import PythonClassMethodModel, \
     PythonStaticMethodModel
 from dlhub_sdk.utils.schemas import validate_against_dlhub_schema
+from dlhub_sdk.utils.types import compose_argument_block
 from dlhub_sdk.version import __version__
 from sklearn import __version__ as skl_version
 from numpy import __version__ as numpy_version
@@ -34,6 +35,10 @@ class TestPythonModels(unittest.TestCase):
         model.set_inputs('ndarray', 'Features for each entry', shape=[None, 4])
         model.set_outputs('ndarray', 'Predicted probabilities of being each iris species',
                           shape=[None, 3])
+
+        # Make sure attempting to set "unpack" fails
+        with self.assertRaises(ValueError):
+            model.set_unpack_inputs(True)
 
         # Add some requirements
         model.add_requirement('scikit-learn', 'detect')
@@ -185,3 +190,45 @@ class TestPythonModels(unittest.TestCase):
         }
         self.assertEqual(output, correct_output)
         validate_against_dlhub_schema(output, 'servable')
+
+    def test_multiarg(self):
+        """Test making descriptions with more than one argument"""
+
+        # Initialize the model
+        model = PythonStaticMethodModel.from_function_pointer(max).set_name('test').set_title('test')
+
+        # Define the inputs and outputs
+        model.set_inputs('tuple', 'Two numbers',
+                         element_types=[
+                             compose_argument_block('float', 'A number'),
+                             compose_argument_block('float', 'A second number')
+                         ])
+        model.set_outputs('float', 'Maximum of the two numbers')
+
+        # Mark that the inputs should be unpacked
+        model.set_unpack_inputs(True)
+
+        # Check the description
+        self.assertEqual(model['servable']['methods']['run'], {
+            'input': {
+                'type': 'tuple',
+                'description': 'Two numbers',
+                'element_types': [
+                    {'type': 'float', 'description': 'A number'},
+                    {'type': 'float', 'description': 'A second number'}
+                ]
+            },
+            'output': {
+                'type': 'float',
+                'description': 'Maximum of the two numbers'
+            },
+            'method_details': {
+                'module': 'builtins',
+                'method_name': 'max',
+                'unpack': True,
+                'autobatch': False
+            },
+            'parameters': {}
+        })
+
+        validate_against_dlhub_schema(model.to_dict(), 'servable')

--- a/dlhub_sdk/utils/types.py
+++ b/dlhub_sdk/utils/types.py
@@ -44,7 +44,7 @@ def compose_argument_block(data_type, description, shape=(), item_type=None,
         python_type (string): Full path of a Python object type
             (e.g., :code:`pymatgen.core.Compostion`)
         properties (dict): Descriptions of the types in a dictionary
-        element_types ([dict] or [list]): Types of elements in a tuple. List of type definition
+        element_types ([dict] or [str]): Types of elements in a tuple. List of type definition
             dictionaries or types as strings.
     Keyword Arguments: Any other details particular to this kind of data
     Returns:

--- a/docs/servable-types.rst
+++ b/docs/servable-types.rst
@@ -42,6 +42,21 @@ Each of these functions takes the type of input and a short description for that
 Certain types of inputs require further information (e.g., ndarrays require the shape of the array).
 See `Argument Types <argument-types.html>`_ for a complete listing of argument types.
 
+Functions that take more than one argument (e.g., ``f(x, y)``) require you to tell DLHub
+to unpack the inputs before running the function.
+As an example::
+
+    from dlhub_sdk.utils.types import compose_argument_block
+    model = PythonStaticMethodServable.from_function_pointer(f)
+    model.set_inputs('tuple', 'Two numbers', element_types=[
+        compose_argument_block('float', 'A number'),
+        compose_argument_block('float', 'A second number')
+    ])
+    model.set_unpack_inputs(True)
+
+Note that we used an input type of "tuple" to indicate that the function takes a fixed number of arguments.
+You can also use a type of "list" for functions that take a variable number of inputs.
+
 Using Static Functions to Create Special Interfaces
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -89,6 +104,8 @@ or adding the code that defines the class to a seperate file (e.g., ``example.py
 of files required by DLHub::
 
     model.add_file('example.py')
+
+As with the Python static methods, you can specify the functions with multiple arguments using ``set_unpack_inputs``.
 
 Keras Models
 ------------


### PR DESCRIPTION
Adds support for Python function servables with >1 input type. Should work both with fixed numbers of types and with variable arguments.