### PR TITLE
Funcx updates #66

### DIFF
--- a/dlhub_sdk/client.py
+++ b/dlhub_sdk/client.py
@@ -75,7 +75,7 @@ class DLHubClient(BaseClient):
                              token_dir=_token_dir, no_local_server=kwargs.get("no_local_server", True),
                              no_browser=kwargs.get("no_browser", True))
             dlh_authorizer = auth_res["dlhub"]
-            fx_authorizer = auth_res["funcx_service"]
+            fx_authorizer = auth_res[fx_scope]
             self._search_client = auth_res["search"]
             self._fx_client = FuncXClient(fx_authorizer=fx_authorizer)
 

--- a/dlhub_sdk/client.py
+++ b/dlhub_sdk/client.py
@@ -223,7 +223,7 @@ class DLHubClient(BaseClient):
         #     raise Exception(r)
 
         # Return the result
-        return DLHubFuture(self, task_id, async_wait) if not asynchronous else task_id
+        return DLHubFuture(self, task_id, async_wait).result() if not asynchronous else task_id
 
     def get_result(self, task_id, verbose=False):
         """Get the result of a task_id

--- a/dlhub_sdk/client.py
+++ b/dlhub_sdk/client.py
@@ -77,7 +77,8 @@ class DLHubClient(BaseClient):
             dlh_authorizer = auth_res["dlhub"]
             fx_authorizer = auth_res[fx_scope]
             self._search_client = auth_res["search"]
-            self._fx_client = FuncXClient(force_login=True,fx_authorizer=fx_authorizer, funcx_service_address='https://dev.funcx.org/api/v1')
+            self._fx_client = FuncXClient(force_login=True,fx_authorizer=fx_authorizer,
+                                          funcx_service_address='https://funcx.org/api/v1')
 
         # funcX endpoint to use
         self.fx_endpoint = '86a47061-f3d9-44f0-90dc-56ddc642c000'

--- a/dlhub_sdk/client.py
+++ b/dlhub_sdk/client.py
@@ -80,7 +80,7 @@ class DLHubClient(BaseClient):
             self._fx_client = FuncXClient(fx_authorizer=fx_authorizer)
 
         # funcX endpoint to use
-        self.fx_endpoint = '2c92a06a-015d-4bfa-924c-b3d0c36bdad7'
+        self.fx_endpoint = '86a47061-f3d9-44f0-90dc-56ddc642c000'
         self.fx_serializer = FuncXSerializer()
         super(DLHubClient, self).__init__("DLHub", environment='dlhub', authorizer=dlh_authorizer,
                                           http_timeout=http_timeout, base_url=DLHUB_SERVICE_ADDRESS,

--- a/dlhub_sdk/client.py
+++ b/dlhub_sdk/client.py
@@ -77,7 +77,7 @@ class DLHubClient(BaseClient):
             dlh_authorizer = auth_res["dlhub"]
             fx_authorizer = auth_res[fx_scope]
             self._search_client = auth_res["search"]
-            self._fx_client = FuncXClient(fx_authorizer=fx_authorizer, funcx_service_address='https://dev.funcx.org/api/v1')
+            self._fx_client = FuncXClient(force_login=True,fx_authorizer=fx_authorizer, funcx_service_address='https://dev.funcx.org/api/v1')
 
         # funcX endpoint to use
         self.fx_endpoint = '86a47061-f3d9-44f0-90dc-56ddc642c000'
@@ -204,7 +204,7 @@ class DLHubClient(BaseClient):
             inputs: Data to be used as input to the function. Can be a string of file paths or URLs
             asynchronous (bool): Whether to return from the function immediately or
                 wait for the execution to finish.
-            async_wait (float): How many sections wait between checking async status
+            async_wait (float): How many seconds to wait between checking async status
         Returns:
             Results of running the servable. If asynchronous, then the task ID
         """
@@ -223,19 +223,20 @@ class DLHubClient(BaseClient):
         #     raise Exception(r)
 
         # Return the result
-        return DLHubFuture(self, task_id, async_wait) if asynchronous else task_id
+        return DLHubFuture(self, task_id, async_wait) if not asynchronous else task_id
 
-    def get_result(self, task_id):
+    def get_result(self, task_id, verbose=False):
         """Get the result of a task_id
 
         Args:
             task_id str: The task's uuid
+            verbose bool: whether or not to return the full dlhub response
         Returns:
             Reult of running the servable
         """
 
         result = self._fx_client.get_result(task_id)
-        if isinstance(result, tuple):
+        if isinstance(result, tuple) and not verbose:
             result = result[0]
         return result
 

--- a/dlhub_sdk/client.py
+++ b/dlhub_sdk/client.py
@@ -81,6 +81,7 @@ class DLHubClient(BaseClient):
 
         # funcX endpoint to use
         self.fx_endpoint = '86a47061-f3d9-44f0-90dc-56ddc642c000'
+        self.fx_endpoint = '2c92a06a-015d-4bfa-924c-b3d0c36bdad7'
         self.fx_serializer = FuncXSerializer()
         super(DLHubClient, self).__init__("DLHub", environment='dlhub', authorizer=dlh_authorizer,
                                           http_timeout=http_timeout, base_url=DLHUB_SERVICE_ADDRESS,

--- a/dlhub_sdk/client.py
+++ b/dlhub_sdk/client.py
@@ -49,13 +49,22 @@ class DLHubClient(BaseClient):
             force_login (bool): Whether to force a login to get new credentials.
                 A login will always occur if ``dlh_authorizer`` or ``search_client``
                 are not provided.
+            no_local_server (bool): Disable spinning up a local server to automatically
+                copy-paste the auth code. THIS IS REQUIRED if you are on a remote server.
+                When used locally with no_local_server=False, the domain is localhost with
+                a randomly chosen open port number.
+                **Default**: ``True``.
+            no_browser (bool): Do not automatically open the browser for the Globus Auth URL.
+                Display the URL instead and let the user navigate to that location manually.
+                **Default**: ``True``.
         Keyword arguments are the same as for BaseClient.
         """
         if force_login or not dlh_authorizer or not search_client:
 
             auth_res = login(services=["search", "dlhub"], app_name="DLHub_Client",
                              client_id=CLIENT_ID, clear_old_tokens=force_login,
-                             token_dir=_token_dir, no_local_server=True, no_browser=True)
+                             token_dir=_token_dir, no_local_server=kwargs.get("no_local_server", True),
+                             no_browser=kwargs.get("no_browser", True))
             dlh_authorizer = auth_res["dlhub"]
             self._search_client = auth_res["search"]
 

--- a/dlhub_sdk/client.py
+++ b/dlhub_sdk/client.py
@@ -81,7 +81,7 @@ class DLHubClient(BaseClient):
 
         # funcX endpoint to use
         self.fx_endpoint = '86a47061-f3d9-44f0-90dc-56ddc642c000'
-        self.fx_endpoint = '2c92a06a-015d-4bfa-924c-b3d0c36bdad7'
+        # self.fx_endpoint = '2c92a06a-015d-4bfa-924c-b3d0c36bdad7'
         self.fx_serializer = FuncXSerializer()
         super(DLHubClient, self).__init__("DLHub", environment='dlhub', authorizer=dlh_authorizer,
                                           http_timeout=http_timeout, base_url=DLHUB_SERVICE_ADDRESS,

--- a/dlhub_sdk/client.py
+++ b/dlhub_sdk/client.py
@@ -55,7 +55,7 @@ class DLHubClient(BaseClient):
 
             auth_res = login(services=["search", "dlhub"], app_name="DLHub_Client",
                              client_id=CLIENT_ID, clear_old_tokens=force_login,
-                             token_dir=_token_dir)
+                             token_dir=_token_dir, no_local_server=True, no_browser=True)
             dlh_authorizer = auth_res["dlhub"]
             self._search_client = auth_res["search"]
 

--- a/dlhub_sdk/utils/futures.py
+++ b/dlhub_sdk/utils/futures.py
@@ -45,7 +45,11 @@ class DLHubFuture(Future):
     def running(self):
         if super().running():
             # If the task isn't already completed, check if it is still running
-            status = self.client.get_task_status(self.task_id)
+            try:
+                status = self.client.get_task_status(self.task_id)
+            except Exception as e:
+                print(e)
+
             # TODO (lw): What if the task fails on the server end? Do we have a "FAILURE" status?
             if 'result' in status:
                 self.set_result(self.client.fx_serializer.deserialize(status['result']))

--- a/dlhub_sdk/utils/futures.py
+++ b/dlhub_sdk/utils/futures.py
@@ -48,7 +48,9 @@ class DLHubFuture(Future):
             try:
                 status = self.client.get_task_status(self.task_id)
             except Exception as e:
-                return True
+                # Check if it is "Task pending"
+                if e.args[0] == "Task pending":
+                    return True
 
             # TODO (lw): What if the task fails on the server end? Do we have a "FAILURE" status?
             if 'result' in status:
@@ -56,6 +58,9 @@ class DLHubFuture(Future):
                     self.set_result(self.client.fx_serializer.deserialize(status['result'][0]))
                 else:
                     self.set_result(self.client.fx_serializer.deserialize(status['result']))
+                return False
+            elif 'exception' in status:
+                self.set_exception(Exception(self.client.fx_serializer.deserialize(status['exception'])))
                 return False
             return True
         return False

--- a/dlhub_sdk/utils/futures.py
+++ b/dlhub_sdk/utils/futures.py
@@ -48,11 +48,14 @@ class DLHubFuture(Future):
             try:
                 status = self.client.get_task_status(self.task_id)
             except Exception as e:
-                print(e)
+                return True
 
             # TODO (lw): What if the task fails on the server end? Do we have a "FAILURE" status?
             if 'result' in status:
-                self.set_result(self.client.fx_serializer.deserialize(status['result']))
+                if isinstance(status['result'], tuple):
+                    self.set_result(self.client.fx_serializer.deserialize(status['result'][0]))
+                else:
+                    self.set_result(self.client.fx_serializer.deserialize(status['result']))
                 return False
             return True
         return False

--- a/dlhub_sdk/utils/futures.py
+++ b/dlhub_sdk/utils/futures.py
@@ -47,8 +47,8 @@ class DLHubFuture(Future):
             # If the task isn't already completed, check if it is still running
             status = self.client.get_task_status(self.task_id)
             # TODO (lw): What if the task fails on the server end? Do we have a "FAILURE" status?
-            if status['status'] == 'COMPLETED':
-                self.set_result(json.loads(status['result']))
+            if 'result' in status:
+                self.set_result(self.client.fx_serializer.deserialize(status['result']))
                 return False
             return True
         return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ jsonpickle>=1.0
 requests>=2.20.0
 mdf_toolbox>=0.4.0
 jsonschema>=3.0.0
+funcx

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ globus-sdk>=1.7.0
 jsonpickle>=1.0
 requests>=2.20.0
 mdf_toolbox>=0.4.0
-jsonschema>=3.0.0
 funcx
+jsonschema>=3.0.0


### PR DESCRIPTION
Updates the SDK to use funcX to perform invocations. The main changes relate to using a funcX client to submit tasks and get results. In addition I included a fx_cache to store function ids of servables.