### PR TITLE
Add get_input_description and get_output_description

### DIFF
--- a/dlhub_sdk/models/servables/python.py
+++ b/dlhub_sdk/models/servables/python.py
@@ -60,6 +60,32 @@ class BasePythonServableModel(BaseServableModel):
         self._output["servable"]["methods"]["run"]["input"] = args
         return self
 
+    def set_input_description(self, description):
+        """Set the human-readable description for this servable's inputs
+
+        This method can be called when implementing a Keras, PyTorch, etc. servable to fill in
+        an empty input description.
+
+        Args:
+            description (name): Human-readable description of the servable's inputs
+        """
+
+        self._output["servable"]["methods"]["run"]["input"]["description"] = description
+        return self
+
+    def set_output_description(self, description):
+        """Set the human-readable description for this servable's inputs
+
+        This method can be called when implementing a Keras, PyTorch, etc. servable to fill in
+        an empty input description.
+
+        Args:
+            description (name): Human-readable description of the servable's inputs
+        """
+
+        self._output["servable"]["methods"]["run"]["output"]["description"] = description
+        return self
+
     def set_outputs(self, data_type, description, shape=(), item_type=None, **kwargs):
         """Define the outputs to the default ("run") function
 

--- a/dlhub_sdk/models/servables/python.py
+++ b/dlhub_sdk/models/servables/python.py
@@ -60,30 +60,32 @@ class BasePythonServableModel(BaseServableModel):
         self._output["servable"]["methods"]["run"]["input"] = args
         return self
 
-    def set_input_description(self, description):
+    def set_input_description(self, description, method='run'):
         """Set the human-readable description for this servable's inputs
 
         This method can be called when implementing a Keras, PyTorch, etc. servable to fill in
         an empty input description.
 
         Args:
-            description (name): Human-readable description of the servable's inputs
+            description (string): Human-readable description of the servable's inputs
+            method (string): Name of the servable method to apply description to (by default, 'run')
         """
 
-        self._output["servable"]["methods"]["run"]["input"]["description"] = description
+        self._output["servable"]["methods"][method]["input"]["description"] = description
         return self
 
-    def set_output_description(self, description):
+    def set_output_description(self, description, method='run'):
         """Set the human-readable description for this servable's inputs
 
         This method can be called when implementing a Keras, PyTorch, etc. servable to fill in
         an empty input description.
 
         Args:
-            description (name): Human-readable description of the servable's inputs
+            description (string): Human-readable description of the servable's inputs
+            method (string): Name of the servable method to apply description to (by default, 'run')
         """
 
-        self._output["servable"]["methods"]["run"]["output"]["description"] = description
+        self._output["servable"]["methods"][method]["output"]["description"] = description
         return self
 
     def set_outputs(self, data_type, description, shape=(), item_type=None, **kwargs):

--- a/examples/mnist/describe_model.py
+++ b/examples/mnist/describe_model.py
@@ -12,8 +12,8 @@ model_info.set_name("mnist_tiny_example")
 model_info.set_domains(["general", "digit recognition"])
 
 #    Describe the outputs in more detail
-model_info['servable']['methods']['run']['output']['description'] = 'Probabilities of being 0-9'
-model_info['servable']['methods']['run']['input']['description'] = 'Image of a digit'
+model_info.set_output_description('Probabilities of being 0-9')
+model_info.set_input_description('Image of a digit')
 
 # Print out the result
 print('\n--> Model Information <--')


### PR DESCRIPTION
Adds 2 new functions to PythonBaseServableModel: `get_input_description` and `get_output_description` as method replacements to `model_info['servable']['methods']['run']['output']['description'] = 'description string'` and `model_info['servable']['methods']['run']['input']['description'] = 'description string'` that is necessary to add human-readable descriptions to the inputs and outputs to Keras models and other models from standard libraries.

Also reflects these changes in the MNIST example in the examples directory.