### PR TITLE
Add visibility specification based on group and user URNs

### DIFF
--- a/dlhub_sdk/models/__init__.py
+++ b/dlhub_sdk/models/__init__.py
@@ -204,7 +204,7 @@ class BaseMetadataModel:
         self._output["dlhub"]["domains"] = domains
         return self
 
-    def set_visibility(self, users=[], groups=[]):
+    def set_visibility(self, users=None, groups=None):
         """Set the list of people this artifact should be visible to.
 
         By default, it will be visible to anyone (["public"]).
@@ -217,10 +217,12 @@ class BaseMetadataModel:
         if not (users or groups):
             visibilities.append('public')
         else:
-            for user in users:
-                visibilities.append('urn:globus:auth:identity:' + user)
-            for group in groups:
-                visibilities.append('urn:globus:groups:id:' + group)
+            if users:
+                for user in users:
+                    visibilities.append('urn:globus:auth:identity:' + user)
+            if groups:
+                for group in groups:
+                    visibilities.append('urn:globus:groups:id:' + group)
         self._output["dlhub"]["visible_to"] = visibilities
         return self
 

--- a/dlhub_sdk/models/__init__.py
+++ b/dlhub_sdk/models/__init__.py
@@ -204,15 +204,24 @@ class BaseMetadataModel:
         self._output["dlhub"]["domains"] = domains
         return self
 
-    def set_visibility(self, visible_to):
-        """Define the list of people and groups who have permissions to see and use this model.
+    def set_visibility(self, users=[], groups=[]):
+        """Set the list of people this artifact should be visible to.
 
         By default, it will be visible to anyone (["public"]).
 
         Args:
-            visible_to ([string]): List of allowed users and groups, listed by GlobusAuth UUID
+            users ([string]): List of GlobusAuth UUIDs of allowed users
+            groups ([string]): List of GlobusAuth UUIDs of allowed Globus groups
         """
-        self._output["dlhub"]["visible_to"] = visible_to
+        visibilities = []
+        if not (users or groups):
+            visibilities.append('public')
+        else:
+            for user in users:
+                visibilities.append('urn:globus:auth:identity:' + user)
+            for group in groups:
+                visibilities.append('urn:globus:groups:id:' + group)
+        self._output["dlhub"]["visible_to"] = visibilities
         return self
 
     def set_doi(self, doi):


### PR DESCRIPTION
Modifies `set_visibility` to accept UUIDs associated with Globus Auth groups and user UUIDs via `users` and `groups` optional arguments. Without either argument the visibility will be set to public (though users desiring to make their datasets public would likely not use set_visibility). User and group UUIDs are then converted to the corresponding URNs and added to the model metadata.

Schemas have already been updated to accommodate URNs.