### PR TITLE
Funcx 0.3.2

### DIFF
--- a/dlhub_sdk/client.py
+++ b/dlhub_sdk/client.py
@@ -93,7 +93,7 @@ class DLHubClient(BaseClient):
                                           openid_authorizer=openid_authorizer,
                                           no_local_server=kwargs.get("no_local_server", True),
                                           no_browser=kwargs.get("no_browser", True),
-                                          funcx_service_address='https://api.funcx.org/v1')
+                                          )
             self._search_client = globus_sdk.SearchClient(authorizer=search_authorizer,
                                                           http_timeout=5 * 60)
 

--- a/dlhub_sdk/version.py
+++ b/dlhub_sdk/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.9.5"
+__version__ = "0.9.6"
 
 # app name to send as part of SDK requests
 app_name = "DLHub SDK v{}".format(__version__)


### PR DESCRIPTION
- updates to be in line with funcx 0.3.2
- note that any servable published now isn't usable from the sdk before this point