### PR TITLE
Support validating either a dict or the BaseModel object

### DIFF
--- a/dlhub_sdk/models/__init__.py
+++ b/dlhub_sdk/models/__init__.py
@@ -16,7 +16,7 @@ import os
 import re
 
 from dlhub_sdk.models.datacite import Datacite, DataciteRelatedIdentifierType, DataciteRelationType
-from dlhub_sdk import __version__
+from dlhub_sdk.version import __version__
 
 name_re = re.compile(r'^\S+$')
 

--- a/dlhub_sdk/models/servables/tests/test_python.py
+++ b/dlhub_sdk/models/servables/tests/test_python.py
@@ -9,8 +9,7 @@ from sklearn import __version__ as skl_version
 from numpy import __version__ as numpy_version
 from pytest import fixture, raises
 
-from dlhub_sdk.models.servables.python import PythonClassMethodModel, \
-    PythonStaticMethodModel
+from dlhub_sdk.models.servables.python import PythonClassMethodModel, PythonStaticMethodModel
 from dlhub_sdk.utils.schemas import validate_against_dlhub_schema
 from dlhub_sdk.utils.types import compose_argument_block
 
@@ -71,7 +70,7 @@ def test_pickle():
             ['method_details']['method_name'] == 'to_dict')
 
     assert [_pickle_path] == model.list_files()
-    validate_against_dlhub_schema(output, 'servable')
+    validate_against_dlhub_schema(model, 'servable')
 
 
 def test_function():

--- a/dlhub_sdk/utils/schemas.py
+++ b/dlhub_sdk/utils/schemas.py
@@ -1,22 +1,30 @@
 """Utilities for validating against DLHub schemas"""
+from typing import Union
+
 from jsonschema import Draft7Validator, RefResolver
 import requests
+
+from dlhub_sdk.models import BaseMetadataModel
 
 _schema_repo = "https://raw.githubusercontent.com/DLHub-Argonne/dlhub_schemas/master/schemas/"
 
 
-def validate_against_dlhub_schema(document, schema_name):
+def validate_against_dlhub_schema(document: Union[dict, BaseMetadataModel], schema_name: str):
     """Validate a metadata document against one of the DLHub schemas
 
     Note: Requires an internet connection
 
     Args:
-        document (dict): Document instance to be validated
+        document: Document instance to be validated
         schema_name (string): Name of schema (e.g., "dataset" for validating datasets).
             For full list, see: https://github.com/DLHub-Argonne/dlhub_schemas
     Raises:
         (jsonschema.SchemaError) If the schema fails to validate
     """
+
+    # Convert to dictionary, if needed
+    if isinstance(document, BaseMetadataModel):
+        document = document.to_dict()
 
     # Make the schema validator
     schema = requests.get("{}/{}.json".format(_schema_repo, schema_name)).json()


### PR DESCRIPTION
Avoids some indecipherable errors when attempting to validate a model.