### PR TITLE
Fix tests for old versions of keras

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,7 +65,7 @@ jobs:
 
           # Adding keras and TF1 for some tests
           if [ -n "${{matrix.cfg.keras-version}}" ]; then
-            pip install keras==${{matrix.cfg.keras-version}} "tensorflow<2" "h5py<3"
+            pip install keras==${{matrix.cfg.keras-version}} "tensorflow<2" "h5py<3" "pyyaml<6"
           else
             # Otherwise, use TF2
             pip uninstall keras


### PR DESCRIPTION
Force pyyaml<6 for old versions of keras because version 6 starts to require users to specify a loader