### PR TITLE
Send debug and options flags in `run` payload

### DIFF
--- a/dlhub_sdk/tests/test_dlhub_client.py
+++ b/dlhub_sdk/tests/test_dlhub_client.py
@@ -53,7 +53,7 @@ def test_get_servables(dl):
 
 def test_run(dl):
     user = "aristana_uchicago"
-    name = "noopv10"
+    name = "noop_v10"
     data = True  # accepts anything as input, but listed as Boolean in DLHub
 
     # Test a synchronous request
@@ -214,6 +214,6 @@ def test_namespace(dl):
 
 
 def test_status(dl):
-    future = dl.run('aristana_uchicago/noopv10', 'test', asynchronous=True)
+    future = dl.run('aristana_uchicago/noop_v10', 'test', asynchronous=True)
     # Need spec for Fx status returns
     assert isinstance(dl.get_task_status(future.task_id), dict)

--- a/dlhub_sdk/tests/test_dlhub_client.py
+++ b/dlhub_sdk/tests/test_dlhub_client.py
@@ -59,12 +59,18 @@ def test_run(dl):
     # Test a synchronous request
     res = dl.run("{}/{}".format(user, name), data, timeout=60)
     # res[0] contains model results, res[1] contains event data JSON
+    assert res == 'Hello world!'
+
+    # Do the same thing with debug mode
+    res = dl.run("{}/{}".format(user, name), data, timeout=60, debug=True)
+    # res[0] contains model results, res[1] contains event data JSON
     assert res[0] == 'Hello world!'
+    assert isinstance(res[1], dict)
 
     # Test an asynchronous request
-    task_id = dl.run("{}/{}".format(user, name), data, asynchronous=True)
-    assert isinstance(task_id, DLHubFuture)
-    assert task_id.result(timeout=60)[0] == 'Hello world!'
+    res = dl.run("{}/{}".format(user, name), data, asynchronous=True)
+    assert isinstance(res, DLHubFuture)
+    assert res.result(timeout=60) == 'Hello world!'
 
 
 @mark.skipif(not is_gha, reason='Avoid running this test except on larger-scale tests of the system')

--- a/dlhub_sdk/tests/test_dlhub_client.py
+++ b/dlhub_sdk/tests/test_dlhub_client.py
@@ -54,7 +54,7 @@ def test_get_servables(dl):
 def test_run(dl):
     user = "aristana_uchicago"
     name = "noopv10"
-    data = True # accepts anything as input, but listed as Boolean in DLHub
+    data = True  # accepts anything as input, but listed as Boolean in DLHub
 
     # Test a synchronous request
     res = dl.run("{}/{}".format(user, name), data, timeout=60)

--- a/dlhub_sdk/tests/test_dlhub_client.py
+++ b/dlhub_sdk/tests/test_dlhub_client.py
@@ -64,7 +64,7 @@ def test_run(dl):
     # Test an asynchronous request
     task_id = dl.run("{}/{}".format(user, name), data, asynchronous=True)
     assert isinstance(task_id, DLHubFuture)
-    assert task_id.result(timeout=60) == 'Hello world!'
+    assert task_id.result(timeout=60)[0] == 'Hello world!'
 
 
 @mark.skipif(not is_gha, reason='Avoid running this test except on larger-scale tests of the system')

--- a/dlhub_sdk/tests/test_dlhub_client.py
+++ b/dlhub_sdk/tests/test_dlhub_client.py
@@ -52,18 +52,19 @@ def test_get_servables(dl):
 
 
 def test_run(dl):
-    user = "zhuozhao_uchicago"
-    name = "noop"
-    data = {"data": ["V", "Co", "Zr"]}
+    user = "aristana_uchicago"
+    name = "noopv10"
+    data = True # accepts anything as input, but listed as Boolean in DLHub
 
     # Test a synchronous request
     res = dl.run("{}/{}".format(user, name), data, timeout=60)
-    assert res == 'Hello'
+    # res[0] contains model results, res[1] contains event data JSON
+    assert res[0] == 'Hello world!'
 
     # Test an asynchronous request
     task_id = dl.run("{}/{}".format(user, name), data, asynchronous=True)
     assert isinstance(task_id, DLHubFuture)
-    assert task_id.result(timeout=60) == 'Hello'
+    assert task_id.result(timeout=60) == 'Hello world!'
 
 
 @mark.skipif(not is_gha, reason='Avoid running this test except on larger-scale tests of the system')
@@ -213,6 +214,6 @@ def test_namespace(dl):
 
 
 def test_status(dl):
-    future = dl.run('zhuozhao_uchicago/noop', 'test', asynchronous=True)
+    future = dl.run('aristana_uchicago/noopv10', 'test', asynchronous=True)
     # Need spec for Fx status returns
     assert isinstance(dl.get_task_status(future.task_id), dict)

--- a/dlhub_sdk/utils/futures.py
+++ b/dlhub_sdk/utils/futures.py
@@ -8,17 +8,19 @@ from time import sleep
 class DLHubFuture(Future):
     """Utility class for simplifying asynchronous execution in DLHub"""
 
-    def __init__(self, client, task_id: str, ping_interval: float):
+    def __init__(self, client, task_id: str, ping_interval: float, debug: bool):
         """
         Args:
-             client (DLHubClient): Already-initialized client, used to check
-             task_id (str): Set the task ID of the
-             ping_interval (float): How often to ping the server to check status in seconds
+             client: Already-initialized client, used to check
+             task_id: Set the task ID of the
+             ping_interval: How often to ping the server to check status in seconds
+             debug: Whether to return the run metadata
         """
         super().__init__()
         self.client = client
         self.task_id = task_id
         self.ping_interval = ping_interval
+        self.debug = debug
 
         # List of pending statuses returned by funcX.
         # TODO: Replace this once funcX stops raising exceptions when a task is pending.
@@ -50,18 +52,24 @@ class DLHubFuture(Future):
         if super().running():
             # If the task isn't already completed, check if it is still running
             try:
-                status = self.client.get_result(self.task_id, verbose=True)
+                results = self.client.get_result(self.task_id, verbose=True)
             except Exception as e:
                 # Check if it is "Task pending". funcX throws an exception on pending.
                 if e.args[0] in self.pending_statuses:
                     return True
-                else:
-                    self.set_exception(e)
-                    return False
 
-            if isinstance(status, tuple):
-                # TODO pass in verbose setting?
-                self.set_result(status[0])
+            # If successfull, `status` now contains:
+            #  (function_return, metadata), run_time
+            (return_val, metadata), _ = results
+
+            if not metadata['success']:
+                self.set_exception(metadata['exc'])
+            else:
+                # If debug: then return return_val and metadata
+                if self.debug:
+                    self.set_result(return_val)
+                else:
+                    self.set_result((return_val, metadata))
                 return False
 
         return False

--- a/dlhub_sdk/utils/futures.py
+++ b/dlhub_sdk/utils/futures.py
@@ -58,6 +58,11 @@ class DLHubFuture(Future):
                 if e.args[0] in self.pending_statuses:
                     return True
 
+                # If not, something has gone wrong and we need to throw an exception
+                else:
+                    self.set_exception(e)
+                    return False
+
             # If successfull, `status` now contains:
             #  (function_return, metadata), run_time
             (return_val, metadata), _ = results

--- a/dlhub_sdk/utils/futures.py
+++ b/dlhub_sdk/utils/futures.py
@@ -72,9 +72,9 @@ class DLHubFuture(Future):
             else:
                 # If debug: then return return_val and metadata
                 if self.debug:
-                    self.set_result(return_val)
-                else:
                     self.set_result((return_val, metadata))
+                else:
+                    self.set_result(return_val)
                 return False
 
         return False


### PR DESCRIPTION
Changes the payload send to FuncX so that it includes a debug flag and method parameters. Also receives the run metadata as a result from the new home_run output format (https://github.com/DLHub-Argonne/home_run/pull/14)

Fixes #125
Fixes #43