### PR TITLE
update version to 0.10.2 for patch

### DIFF
--- a/dlhub_sdk/version.py
+++ b/dlhub_sdk/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.10.1"
+__version__ = "0.10.2"
 
 # app name to send as part of SDK requests
 app_name = "DLHub SDK v{}".format(__version__)


### PR DESCRIPTION
Release for 0.10.1 appears to not have packaged code correctly -- the code in the PyPI package does not align with the code in the `master` branch.

I have a theory that it's because we created a 0.10.1 tag a while back before we realized more things needed to be update for 0.10.1. My plan is to release a 0.10.2 patch and see if that works.