### PR TITLE
add version bounds for protobuf and pyyaml packages to test-requirements.txt

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,7 +60,7 @@ jobs:
 
           # Adding keras and TF1 for some tests
           if [ -n "${{matrix.cfg.keras-version}}" ]; then
-            pip install keras==${{matrix.cfg.keras-version}} "tensorflow<2" "h5py<3" "pyyaml<6"
+            pip install keras==${{matrix.cfg.keras-version}} "tensorflow<2" "h5py<3" "pyyaml<6" "protobuf<4"
           else
             # Otherwise, use TF2
             pip uninstall keras

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,5 +7,3 @@ pytest
 pytest-cov
 mdf-connect-client>=0.3.8
 pytest-timeout
-protobuf>3,<4
-pyyaml>5,<6

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,3 +7,5 @@ pytest
 pytest-cov
 mdf-connect-client>=0.3.8
 pytest-timeout
+protobuf>3,<4
+pyyaml>5,<6


### PR DESCRIPTION
Two of the required packages in their latest versions are no longer compatible with the tests that are run for TensorFlow 1.x versions. To resolve this issue, the `test-requirements.txt` file will specify the version number limits for those packages that allow the tests to run.