### PR TITLE
add servable editing to sdk

### DIFF
--- a/dlhub_sdk/client.py
+++ b/dlhub_sdk/client.py
@@ -410,6 +410,20 @@ class DLHubClient(BaseClient):
         task_id = response.data['task_id']
         return task_id
 
+    def edit_servable(self, servable_query: str, **kwargs) -> str:
+        """Edit the indicated servable using kwargs
+
+        Args:
+            servable_query (string): query to locate desired servable
+            kwargs: the arg name is the property to be changed and the value is the new value
+        Returns:
+            (string): task id of the edit request, can be used to check its status
+        """
+        metadata = {}
+
+        for key, value in kwargs.items():
+            metadata[key] = value
+
     def search(self, query, advanced=False, limit=None, only_latest=True):
         """Query the DLHub servable library
 

--- a/dlhub_sdk/client.py
+++ b/dlhub_sdk/client.py
@@ -418,7 +418,7 @@ class DLHubClient(BaseClient):
         task_id = response.data['task_id']
         return task_id
 
-    def edit_servable(self, servable_name: str, *, model: BaseServableModel = None, changes: dict[str, str] = None) -> str:
+    def edit_servable(self, servable_name: str, *, model: BaseServableModel = None, changes: dict[str, str] = None) -> dict:
         """Edit servable metadata from its name and model object or dict of changes
 
         Args:
@@ -428,7 +428,7 @@ class DLHubClient(BaseClient):
                             e.g. the input description is located at `servable.methods.run.input.description`
                             the full structure of the metadata can be found at <INSERT LINK TO DOCS HERE>
         Returns:
-            (string): status of the edit request
+            (dict): the result of the edit request
         Raises:
             ValueError: if the user provides an invalid key in changes or an unsatisfactory servable_name (points to more than one servable)
             Exception: if the user attempts to edit a servable they do not own or a property they cannot edit
@@ -448,9 +448,9 @@ class DLHubClient(BaseClient):
         except SchemaError:
             raise ValueError("dl.edit_servable was supplied invalid replacement data")  # traceback will show the SchemaError
 
-        res = self.post(f"/servables/{self.get_username()}/{servable_name}", json_body=metadata)
+        res = self.put(f"/servables/{self.get_username()}/{servable_name}", json_body=metadata)
 
-        return res["status"]
+        return res
 
     def _edit_dict(self, dct: dict, keys: list[str], data: Any) -> dict:
         """Edit the given dict such that the value found by keys becomes data

--- a/dlhub_sdk/tests/test_dlhub_client.py
+++ b/dlhub_sdk/tests/test_dlhub_client.py
@@ -88,6 +88,12 @@ def test_submit(dl):
     dl.publish_servable(model)
 
 
+def test_edit(dl):
+    res = dl.edit_servable("noop_v10", changes={"servable.methods.run.output.description": "'Hello, world!'"})
+    with open("test_res.txt", "w") as f:
+        f.write(str(res))
+
+
 def test_describe_model(dl):
     # Find the 1d_norm function from the test user (should be there)
     description = dl.describe_servable('dlhub.test_gmail/1d_norm')

--- a/dlhub_sdk/utils/search.py
+++ b/dlhub_sdk/utils/search.py
@@ -18,6 +18,9 @@ class DLHubSearchHelper(SearchHelper):
         """
         super(DLHubSearchHelper, self).__init__("dlhub", search_client=search_client, **kwargs)
 
+    def search(self, q=None, advanced=False, limit=None, info=False, reset_query=True):
+        return super().exclude_field("dlhub.deleted", True).search(q, advanced, limit, info, reset_query)
+
     def match_owner(self, owner):
         """Add a model owner to the query.
 


### PR DESCRIPTION
Not ready to be merged yet, remains untested. The DLHub Service has a corresponding update that adds the route this method requires. Considerations for deleting servables are also included, but the `delete_servable` function is not yet implemented.