### PR TITLE
Funcx 1.0.0

### DIFF
--- a/dlhub_sdk/client.py
+++ b/dlhub_sdk/client.py
@@ -18,6 +18,7 @@ from dlhub_sdk.utils.futures import DLHubFuture
 from dlhub_sdk.utils.schemas import validate_against_dlhub_schema
 from dlhub_sdk.utils.search import DLHubSearchHelper, get_method_details, filter_latest
 from dlhub_sdk.utils.validation import validate
+from dlhub_sdk.utils.funcx_login_manager import FuncXLoginManager
 
 # Directory for authentication tokens
 _token_dir = os.path.expanduser("~/.dlhub/credentials")
@@ -110,11 +111,10 @@ class DLHubClient(BaseClient):
             search_authorizer = auth_res['search']
 
         # Define the subclients needed by the service
-        self._fx_client = FuncXClient(fx_authorizer=fx_authorizer,
-                                      search_authorizer=search_authorizer,
-                                      openid_authorizer=openid_authorizer,
-                                      no_local_server=kwargs.get("no_local_server", True),
-                                      no_browser=kwargs.get("no_browser", True))
+
+        login_manager = FuncXLoginManager(authorizers=auth_res)
+        self._fx_client = FuncXClient(login_manager=login_manager)
+
         self._search_client = globus_sdk.SearchClient(authorizer=search_authorizer,
                                                       transport_params={"http_timeout": http_timeout})
 

--- a/dlhub_sdk/utils/funcx_login_manager.py
+++ b/dlhub_sdk/utils/funcx_login_manager.py
@@ -47,4 +47,3 @@ class FuncXLoginManager:
 
     def logout(self):
         log.warning("logout cannot be invoked from here!")
-

--- a/dlhub_sdk/utils/funcx_login_manager.py
+++ b/dlhub_sdk/utils/funcx_login_manager.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import logging
+import globus_sdk
+from globus_sdk.scopes import AuthScopes, SearchScopes
+from funcx.sdk.web_client import FuncxWebClient
+from funcx import FuncXClient
+
+log = logging.getLogger(__name__)
+
+
+class FuncXLoginManager:
+    """
+    Implements the funcx.sdk.login_manager.protocol.LoginManagerProtocol class.
+    https://github.com/funcx-faas/funcX/blob/main/funcx_sdk/funcx/sdk/login_manager/protocol.py#L18
+    """
+    SCOPES = [
+        FuncXClient.FUNCX_SCOPE,
+        AuthScopes.openid,
+        SearchScopes.all
+    ]
+
+    def __init__(self, authorizers: dict[str, globus_sdk.RefreshTokenAuthorizer]):
+        self.authorizers = authorizers
+
+    def get_auth_client(self) -> globus_sdk.AuthClient:
+        return globus_sdk.AuthClient(
+            authorizer=self.authorizers[AuthScopes.openid]
+        )
+
+    def get_search_client(self) -> globus_sdk.SearchClient:
+        return globus_sdk.SearchClient(
+            authorizer=self.authorizers[SearchScopes.all]
+        )
+
+    def get_funcx_web_client(
+        self, *, base_url: str | None = None, app_name: str | None = None
+    ) -> FuncxWebClient:
+        return FuncxWebClient(
+            base_url=base_url,
+            app_name=app_name,
+            authorizer=self.authorizers[FuncXClient.FUNCX_SCOPE],
+        )
+
+    def ensure_logged_in(self):
+        log.warning("ensure_logged_in cannot be invoked from here!")
+
+    def logout(self):
+        log.warning("logout cannot be invoked from here!")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ globus-sdk>=3,<4
 requests>=2.24.0
 mdf_toolbox>=0.5.4
 jsonschema>=3.2.0
-funcx>=0.3.6
+funcx>=1.0.0
 pydantic


### PR DESCRIPTION
Updates to the authorizer management to support funcx v1.0.0. 

This adds Nick's loginmanager to replace the authorizers being passed into the funcx client. The change brings us back to needing a single login to start the dlhub client.