### PR TITLE
update test model to noop_v11 since v10 has been corrupted

### DIFF
--- a/dlhub_sdk/tests/test_dlhub_client.py
+++ b/dlhub_sdk/tests/test_dlhub_client.py
@@ -53,7 +53,7 @@ def test_get_servables(dl):
 
 def test_run(dl):
     user = "aristana_uchicago"
-    name = "noop_v10"
+    name = "noop_v11"  # published 2/22/2022
     data = True  # accepts anything as input, but listed as Boolean in DLHub
 
     # Test a synchronous request
@@ -220,6 +220,6 @@ def test_namespace(dl):
 
 
 def test_status(dl):
-    future = dl.run('aristana_uchicago/noop_v10', True, asynchronous=True)
+    future = dl.run('aristana_uchicago/noop_v11', True, asynchronous=True)
     # Need spec for Fx status returns
     assert isinstance(dl.get_task_status(future.task_id), dict)


### PR DESCRIPTION
- v10 no longer runs without throwing an `ImportError: module home_run not found` error, I think because something happened to the container (ie got deleted or is inaccessible in some way?) such that it's using the funcx default now