### PR TITLE
immediate patch for "Python object" validation errors

### DIFF
--- a/dlhub_sdk/client.py
+++ b/dlhub_sdk/client.py
@@ -243,7 +243,7 @@ class DLHubClient(BaseClient):
         return get_method_details(metadata, method)
 
     def run(self, name: str, inputs: Any, parameters: Optional[Dict[str, Any]] = None,
-            asynchronous: bool = False, debug: bool = False, validate_input: bool = True,
+            asynchronous: bool = False, debug: bool = False, validate_input: bool = False,
             async_wait: float = 5, timeout: Optional[float] = None)\
             -> Union[
                 DLHubFuture,

--- a/dlhub_sdk/tests/test_dlhub_client.py
+++ b/dlhub_sdk/tests/test_dlhub_client.py
@@ -61,6 +61,11 @@ def test_run(dl):
     # res[0] contains model results, res[1] contains event data JSON
     assert res == 'Hello world!'
 
+    # Do the same thing with input validation
+    res = dl.run("{}/{}".format(user, name), data, timeout=60, validate_input=True)
+    # res[0] contains model results, res[1] contains event data JSON
+    assert res == 'Hello world!'
+
     # Do the same thing with debug mode
     res = dl.run("{}/{}".format(user, name), data, timeout=60, debug=True)
     # res[0] contains model results, res[1] contains event data JSON


### PR DESCRIPTION
Just turns off input validation by default. This branch should be left open while options for a permanent solution and the eventual re-enabling of validation are considered and worked on.