### PR TITLE
proposed solution for error involving enum representation

### DIFF
--- a/dlhub_sdk/models/__init__.py
+++ b/dlhub_sdk/models/__init__.py
@@ -16,6 +16,7 @@ import os
 import re
 
 from dlhub_sdk.models.datacite import Datacite, DataciteRelatedIdentifierType, DataciteRelationType
+from dlhub_sdk.utils.types import enum_types_to_values
 from dlhub_sdk.version import __version__
 
 name_re = re.compile(r'^\S+$')
@@ -404,6 +405,9 @@ class BaseMetadataModel(BaseModel):
 
         # Make a copy of the output
         out = self.dict(exclude_none=True).copy()
+
+        # Convert enums to their values
+        out = enum_types_to_values(out)
 
         # Prepare the files
         if simplify_paths:

--- a/dlhub_sdk/utils/types.py
+++ b/dlhub_sdk/utils/types.py
@@ -1,5 +1,7 @@
 """Utilities for generating descriptions of data types"""
 from datetime import datetime, timedelta
+from enum import Enum
+from typing import Union
 from six import string_types
 
 
@@ -112,3 +114,20 @@ def compose_argument_block(data_type, description, shape=None, item_type=None,
     # Add in any kwargs
     args.update(**kwargs)
     return args
+
+
+def enum_types_to_values(data: Union[dict, list]) -> Union[dict, list]:
+    if isinstance(data, dict):
+        for key in data:
+            if isinstance(data[key], Enum):
+                data[key] = data[key].value
+            elif isinstance(data[key], dict) or isinstance(data[key], list):
+                data[key] = enum_types_to_values(data[key])
+    else:
+        for i, ele in enumerate(data):
+            if isinstance(ele, Enum):
+                data[i] = data[i].value
+            elif isinstance(ele, dict) or isinstance(ele, list):
+                data[i] = enum_types_to_values(ele)
+
+    return data


### PR DESCRIPTION
I just went ahead and made some metadata using `model.to_dict()` and I realized that all of the `Enum` types were being stored as such types rather than as the values of those types. i.e. `DataciteDescriptionType` rather than `DataciteDescriptionType.value`, which is just: "Abstract" (for example). To resolve this, I added a procedure to `model.to_dict()` that performs the above conversion. I am not aware of any consequences of this change, but please enlighten me if it causes problems downstream.