### PR TITLE
put upper limit on funcx sdk version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ globus-sdk>=3,<4
 requests>=2.24.0
 mdf_toolbox>=0.5.4
 jsonschema>=3.2.0
-funcx>=1.0.11
+funcx>=1.0.11,<2.0.0
 pydantic
 numpy
 PyGithub


### PR DESCRIPTION
- in funcx 2.0.0 breaking changes were made in the transition to GlobusCompute -- put an upper limit on the package version until we can sort it out