### PR TITLE
186 update dlhub sdk for globus compute

### DIFF
--- a/dlhub_sdk/client.py
+++ b/dlhub_sdk/client.py
@@ -11,7 +11,7 @@ from globus_sdk import BaseClient
 from globus_sdk.authorizers import GlobusAuthorizer
 from mdf_toolbox import login, logout
 from mdf_toolbox.globus_search.search_helper import SEARCH_LIMIT
-from funcx.sdk.client import FuncXClient
+from globus_compute_sdk import Client as FuncXClient
 from globus_sdk.scopes import AuthScopes, SearchScopes
 
 from dlhub_sdk.config import DLHUB_SERVICE_ADDRESS, CLIENT_ID, GLOBUS_SEARCH_LAMBDA_SCOPE

--- a/dlhub_sdk/tests/test_dlhub_client.py
+++ b/dlhub_sdk/tests/test_dlhub_client.py
@@ -104,7 +104,7 @@ def test_run(dl):
 def test_submit(dl, mocker):  # noqa: F811 (flake8 does not understand usage)
 
     # patch build_container, register_funcx, and search_ingest
-    mocker.patch("funcx.sdk.client.FuncXClient.build_container", return_value="f53e2175-39c5-4522-bc6c-0e68625e3c20")
+    mocker.patch("globus_compute_sdk.Client.build_container", return_value="f53e2175-39c5-4522-bc6c-0e68625e3c20")
     mocker.patch("dlhub_sdk.utils.publish.register_funcx", return_value="6af11a75-f751-4e6d-982f-9ae513c56d63")
     mocker.patch("dlhub_sdk.utils.publish.search_ingest", return_value=None)
     # patch requests.post

--- a/dlhub_sdk/utils/funcx_login_manager.py
+++ b/dlhub_sdk/utils/funcx_login_manager.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import logging
 import globus_sdk
 from globus_sdk.scopes import AuthScopes, SearchScopes
-from funcx.sdk.web_client import FuncxWebClient
-from funcx import FuncXClient
+from globus_compute_sdk.sdk.web_client import WebClient as FuncxWebClient
+from globus_compute_sdk import Client as FuncXClient
 
 log = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ class FuncXLoginManager:
             authorizer=self.authorizers[SearchScopes.all]
         )
 
-    def get_funcx_web_client(
+    def get_web_client(
         self, *, base_url: str | None = None, app_name: str | None = None
     ) -> FuncxWebClient:
         return FuncxWebClient(

--- a/dlhub_sdk/utils/publish.py
+++ b/dlhub_sdk/utils/publish.py
@@ -2,7 +2,7 @@ import logging
 import json
 import requests
 
-from funcx import ContainerSpec
+from globus_compute_sdk import ContainerSpec
 from time import sleep
 import github
 from dlhub_sdk.config import GLOBUS_SEARCH_WRITER_LAMBDA

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ globus-sdk>=3,<4
 requests>=2.24.0
 mdf_toolbox>=0.5.4
 jsonschema>=3.2.0
-funcx>=1.0.11,<2.0.0
+globus-compute-sdk>=2.0.0
 pydantic
 numpy
 PyGithub


### PR DESCRIPTION
This represents the minimal changes to get the DLHub SDK to use globus_compute w/o the funcx wrapper package.  The goal was to only change the imports, and that's pretty much how it panned out.  Tests pass on my local machine.