### PR TITLE
Respect requirements.txt for container builds if it is provided

### DIFF
--- a/dlhub_sdk/utils/publish.py
+++ b/dlhub_sdk/utils/publish.py
@@ -34,6 +34,16 @@ def create_container_spec(metadata):
         # There are no python dependencies
         pass
 
+    # If there's a requirements.txt in the payload, add it to the dependencies
+    fileslist = []
+    try:
+        fileslist = metadata['dlhub']['files']['other']
+    except KeyError:
+        pass
+
+    if 'requirements.txt' in fileslist:
+        dependencies.append("--requirement requirements.txt")
+
     model_location = None
     # If the model was uploaded using a signed URL, it will have a
     # transfer_method of S3 in its metadata.


### PR DESCRIPTION
put "--requirement requirements.txt" in dependencies if there is a
requirements.txt listed in the model metadata